### PR TITLE
Simplify Engine trait

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,9 +1,8 @@
-use chess::{Board, ChessMove};
+use chess::ChessMove;
 
 pub trait Engine {
     fn start(&mut self, time: u64);
     fn stop(&mut self);
     fn update(&mut self, mv: ChessMove);
     fn restart(&mut self);
-    fn get_status(&self) -> Board;
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,4 @@
-use crate::io::output::send_move;
-use chess::{Board, ChessMove, MoveGen};
-use rand::seq::SliceRandom;
+use chess::{Board, ChessMove};
 
 pub trait Engine {
     fn start(&mut self, time: u64);
@@ -8,42 +6,4 @@ pub trait Engine {
     fn update(&mut self, mv: ChessMove);
     fn restart(&mut self);
     fn get_status(&self) -> Board;
-}
-
-pub struct RandomEngine {
-    pub pos: Board,
-}
-
-impl Engine for RandomEngine {
-    fn start(&mut self, _time: u64) {
-        send_move(self.next_move())
-    }
-
-    fn stop(&mut self) {
-        send_move(self.next_move())
-    }
-
-    fn update(&mut self, mv: ChessMove) {
-        self.pos = self.pos.make_move_new(mv);
-    }
-
-    fn restart(&mut self) {
-        self.pos = Board::default();
-    }
-
-    fn get_status(&self) -> Board {
-        self.pos.clone()
-    }
-}
-
-impl RandomEngine {
-    fn next_move(&mut self) -> ChessMove {
-        let moves = MoveGen::new_legal(&self.pos)
-            .into_iter()
-            .collect::<Vec<ChessMove>>();
-
-        let mv = moves.choose(&mut rand::thread_rng()).unwrap();
-        self.pos = self.pos.make_move_new(*mv);
-        mv.clone()
-    }
 }

--- a/src/io/uci.rs
+++ b/src/io/uci.rs
@@ -14,21 +14,7 @@ pub struct UciResult {
 
 pub fn handle_uci(uci: &String, engine: &mut dyn Engine, next_color: Color) -> UciResult {
     let tokens: Vec<&str> = uci.split(' ').collect();
-    let mut time: Option<u64> = None;
-    for i in (1..tokens.len()).step_by(2) {
-        if tokens[i] == "movetime" {
-            time = Some(tokens[i + 1].parse().unwrap());
-            break;
-        }
-        if tokens[i] == "wtime" && next_color == White {*
-            time = Some(tokens[i + 1].parse().unwrap());
-            break;
-        }
-        if tokens[i] == "btime" && next_color == Black {
-            time = Some(tokens[i + 1].parse().unwrap());
-            break;
-        }
-    }
+    let mut time: Option<u64> = get_time(&tokens, next_color);
     match tokens[0] {
         "uci" => start(),
         "isready" => is_ready(),
@@ -39,6 +25,21 @@ pub fn handle_uci(uci: &String, engine: &mut dyn Engine, next_color: Color) -> U
         "quit" => quit(),
         &_ => UciResult { msg: Some("Unknown command |".to_string() + uci + "|"), next_color: next_color }
     }
+}
+
+fn get_time(tokens: &Vec<&str>, next_color: Color) -> Option<u64> {
+    for i in (1..tokens.len()).step_by(2) {
+        if tokens[i] == "movetime" {
+            return Some(tokens[i + 1].parse().unwrap());
+        }
+        if tokens[i] == "wtime" && next_color == White {
+            return Some(tokens[i + 1].parse().unwrap());
+        }
+        if tokens[i] == "btime" && next_color == Black {
+            return Some(tokens[i + 1].parse().unwrap());
+        }
+    }
+    None
 }
 
 fn start() -> UciResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use crate::minmax_engine::MinMaxEngine;
 use crate::io::output::send;
 use chess::Board;
+use chess::Color::White;
 use crate::io::uci;
 
 mod engine;
@@ -13,6 +14,7 @@ mod random_engine;
 fn main() {
     let mut input = String::new();
     let mut engine = MinMaxEngine::new(Board::default());
+    let mut next_color = White;
     let stdin = std::io::stdin();
     loop {
         stdin.read_line(&mut input).expect("panic message");
@@ -22,10 +24,11 @@ fn main() {
         if input.ends_with('\r') {
             input.pop();
         }
-        let result = uci::handle_uci(&input, &mut engine);
-        if result.is_some() {
-            send(result.unwrap())
+        let result = uci::handle_uci(&input, &mut engine, next_color);
+        if result.msg.is_some() {
+            send(result.msg.unwrap())
         }
+        next_color = result.next_color;
         input.clear()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod minmax_engine;
 
 mod features;
 mod io;
+mod random_engine;
 
 fn main() {
     let mut input = String::new();

--- a/src/minmax_engine.rs
+++ b/src/minmax_engine.rs
@@ -43,10 +43,6 @@ impl Engine for MinMaxEngine {
     fn restart(&mut self) {
         self.pos = Board::default();
     }
-
-    fn get_status(&self) -> Board {
-        self.pos.clone()
-    }
 }
 
 impl MinMaxEngine {
@@ -321,8 +317,8 @@ mod checkmate_tests {
     // https://www.chess.com/forum/view/more-puzzles/hardest-mate-in-1-puzzles
     // https://www.chess.com/forum/view/livechess/practice-your-checkmate-in-4-moves-in-24-puzzles
     #[test_case(
-        "r1b2b1r/pp3Qp1/2nkn2p/3ppP1p/P1p5/1NP1NB2/1PP1PPR1/1K1R3q w - - 0 1",
-        1
+    "r1b2b1r/pp3Qp1/2nkn2p/3ppP1p/P1p5/1NP1NB2/1PP1PPR1/1K1R3q w - - 0 1",
+    1
     )]
     #[test_case("r4r1k/1R1R2p1/7p/8/8/3Q1Ppq/P7/6K1 w - - 0 1", 4)]
     #[test_case("3rr1k1/pp3ppp/3b4/2p5/2Q5/6qP/PPP1B1P1/R1B2K1R b - - 0 1", 4)]

--- a/src/random_engine.rs
+++ b/src/random_engine.rs
@@ -1,0 +1,42 @@
+use chess::{Board, ChessMove, MoveGen};
+use crate::engine::{Engine};
+use crate::io::output::send_move;
+use rand::seq::SliceRandom;
+
+pub struct RandomEngine {
+    pub pos: Board,
+}
+
+impl Engine for RandomEngine {
+    fn start(&mut self, _time: u64) {
+        send_move(self.next_move())
+    }
+
+    fn stop(&mut self) {
+        send_move(self.next_move())
+    }
+
+    fn update(&mut self, mv: ChessMove) {
+        self.pos = self.pos.make_move_new(mv);
+    }
+
+    fn restart(&mut self) {
+        self.pos = Board::default();
+    }
+
+    fn get_status(&self) -> Board {
+        self.pos.clone()
+    }
+}
+
+impl RandomEngine {
+    fn next_move(&mut self) -> ChessMove {
+        let moves = MoveGen::new_legal(&self.pos)
+            .into_iter()
+            .collect::<Vec<ChessMove>>();
+
+        let mv = moves.choose(&mut rand::thread_rng()).unwrap();
+        self.pos = self.pos.make_move_new(*mv);
+        mv.clone()
+    }
+}

--- a/src/random_engine.rs
+++ b/src/random_engine.rs
@@ -23,10 +23,6 @@ impl Engine for RandomEngine {
     fn restart(&mut self) {
         self.pos = Board::default();
     }
-
-    fn get_status(&self) -> Board {
-        self.pos.clone()
-    }
 }
 
 impl RandomEngine {


### PR DESCRIPTION
After #2 we use Engine.get_status only to get color to move so I made main manage color and removed Engine.get_status to simplify trait. 
I also moved random engine from engine.rs.